### PR TITLE
Pass copy of input to transform method.

### DIFF
--- a/apps/v1beta1/deployment.go
+++ b/apps/v1beta1/deployment.go
@@ -39,7 +39,7 @@ func PatchDeployment(c kubernetes.Interface, cur *apps.Deployment, transform fun
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.AppsV1beta1().Deployments(cur.Namespace).Update(transform(cur))
+			result, e2 = c.AppsV1beta1().Deployments(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/apps/v1beta1/statefulset.go
+++ b/apps/v1beta1/statefulset.go
@@ -39,7 +39,7 @@ func PatchStatefulSet(c kubernetes.Interface, cur *apps.StatefulSet, transform f
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateStatefulSet(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.AppsV1beta1().StatefulSets(cur.Namespace).Update(transform(cur))
+			result, e2 = c.AppsV1beta1().StatefulSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update StatefulSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/batch/v1/job.go
+++ b/batch/v1/job.go
@@ -38,7 +38,7 @@ func PatchJob(c kubernetes.Interface, cur *batch.Job, transform func(*batch.Job)
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.BatchV1().Jobs(cur.Namespace).Update(transform(cur))
+			result, e2 = c.BatchV1().Jobs(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Job %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/batch/v1beta1/cronjob.go
+++ b/batch/v1beta1/cronjob.go
@@ -38,7 +38,7 @@ func PatchCronJob(c kubernetes.Interface, cur *batch.CronJob, transform func(*ba
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateCronJob(c kubernetes.Interface, meta metav1.ObjectMeta, transform 
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.BatchV1beta1().CronJobs(cur.Namespace).Update(transform(cur))
+			result, e2 = c.BatchV1beta1().CronJobs(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update CronJob %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/certificates/v1beta1/csr.go
+++ b/certificates/v1beta1/csr.go
@@ -38,7 +38,7 @@ func PatchCSR(c kubernetes.Interface, cur *certificates.CertificateSigningReques
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateCSR(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CertificatesV1beta1().CertificateSigningRequests().Update(transform(cur))
+			result, e2 = c.CertificatesV1beta1().CertificateSigningRequests().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update CertificateSigningRequest %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/configmap.go
+++ b/core/v1/configmap.go
@@ -38,7 +38,7 @@ func PatchConfigMap(c kubernetes.Interface, cur *core.ConfigMap, transform func(
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateConfigMap(c kubernetes.Interface, meta metav1.ObjectMeta, transfor
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().ConfigMaps(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().ConfigMaps(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update ConfigMap %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/node.go
+++ b/core/v1/node.go
@@ -39,7 +39,7 @@ func PatchNode(c kubernetes.Interface, cur *core.Node, transform func(*core.Node
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateNode(c kubernetes.Interface, meta metav1.ObjectMeta, transform fun
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().Nodes().Update(transform(cur))
+			result, e2 = c.CoreV1().Nodes().Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Node %s due to %v.", attempt, cur.Name, e2)

--- a/core/v1/pod.go
+++ b/core/v1/pod.go
@@ -39,7 +39,7 @@ func PatchPod(c kubernetes.Interface, cur *core.Pod, transform func(*core.Pod) *
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdatePod(c kubernetes.Interface, meta metav1.ObjectMeta, transform func
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().Pods(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().Pods(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Pod %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/rc.go
+++ b/core/v1/rc.go
@@ -39,7 +39,7 @@ func PatchRC(c kubernetes.Interface, cur *core.ReplicationController, transform 
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateRC(c kubernetes.Interface, meta metav1.ObjectMeta, transform func(
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().ReplicationControllers(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().ReplicationControllers(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update ReplicationController %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/secret.go
+++ b/core/v1/secret.go
@@ -38,7 +38,7 @@ func PatchSecret(c kubernetes.Interface, cur *core.Secret, transform func(*core.
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateSecret(c kubernetes.Interface, meta metav1.ObjectMeta, transform f
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().Secrets(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().Secrets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Secret %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/service.go
+++ b/core/v1/service.go
@@ -38,7 +38,7 @@ func PatchService(c kubernetes.Interface, cur *core.Service, transform func(*cor
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateService(c kubernetes.Interface, meta metav1.ObjectMeta, transform 
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().Services(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().Services(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Service %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/core/v1/serviceaccount.go
+++ b/core/v1/serviceaccount.go
@@ -38,7 +38,7 @@ func PatchServiceAccount(c kubernetes.Interface, cur *core.ServiceAccount, trans
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateServiceAccount(c kubernetes.Interface, meta metav1.ObjectMeta, tra
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.CoreV1().ServiceAccounts(cur.Namespace).Update(transform(cur))
+			result, e2 = c.CoreV1().ServiceAccounts(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update ServiceAccount %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/extensions/v1beta1/daemonset.go
+++ b/extensions/v1beta1/daemonset.go
@@ -39,7 +39,7 @@ func PatchDaemonSet(c kubernetes.Interface, cur *extensions.DaemonSet, transform
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func TryUpdateDaemonSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfor
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.ExtensionsV1beta1().DaemonSets(cur.Namespace).Update(transform(cur))
+			result, e2 = c.ExtensionsV1beta1().DaemonSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update DaemonSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/extensions/v1beta1/deployment.go
+++ b/extensions/v1beta1/deployment.go
@@ -39,7 +39,7 @@ func PatchDeployment(c kubernetes.Interface, cur *extensions.Deployment, transfo
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateDeployment(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.ExtensionsV1beta1().Deployments(cur.Namespace).Update(transform(cur))
+			result, e2 = c.ExtensionsV1beta1().Deployments(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Deployment %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/extensions/v1beta1/replicaset.go
+++ b/extensions/v1beta1/replicaset.go
@@ -39,7 +39,7 @@ func PatchReplicaSet(c kubernetes.Interface, cur *extensions.ReplicaSet, transfo
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func TryUpdateReplicaSet(c kubernetes.Interface, meta metav1.ObjectMeta, transfo
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.ExtensionsV1beta1().ReplicaSets(cur.Namespace).Update(transform(cur))
+			result, e2 = c.ExtensionsV1beta1().ReplicaSets(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update ReplicaSet %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/rbac/v1beta1/role.go
+++ b/rbac/v1beta1/role.go
@@ -38,7 +38,7 @@ func PatchRole(c kubernetes.Interface, cur *rbac.Role, transform func(*rbac.Role
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateRole(c kubernetes.Interface, meta metav1.ObjectMeta, transform fun
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.RbacV1beta1().Roles(cur.Namespace).Update(transform(cur))
+			result, e2 = c.RbacV1beta1().Roles(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update Role %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)

--- a/rbac/v1beta1/rolebinding.go
+++ b/rbac/v1beta1/rolebinding.go
@@ -38,7 +38,7 @@ func PatchRoleBinding(c kubernetes.Interface, cur *rbac.RoleBinding, transform f
 		return nil, err
 	}
 
-	modJson, err := json.Marshal(transform(cur))
+	modJson, err := json.Marshal(transform(cur.DeepCopy()))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func TryUpdateRoleBinding(c kubernetes.Interface, meta metav1.ObjectMeta, transf
 		if kerr.IsNotFound(e2) {
 			return false, e2
 		} else if e2 == nil {
-			result, e2 = c.RbacV1beta1().RoleBindings(cur.Namespace).Update(transform(cur))
+			result, e2 = c.RbacV1beta1().RoleBindings(cur.Namespace).Update(transform(cur.DeepCopy()))
 			return e2 == nil, nil
 		}
 		glog.Errorf("Attempt %d failed to update RoleBinding %s/%s due to %v.", attempt, cur.Namespace, cur.Name, e2)


### PR DESCRIPTION
If the callers want to keep the modified object, they need to assign the returned object.
This allows user to avoid modifying the original object if the api call fails for some reason.