### PR TITLE
Check for existence of "node-role.kubernetes.io/master" to detect master

### DIFF
--- a/tools/analytics/analytics.go
+++ b/tools/analytics/analytics.go
@@ -47,9 +47,7 @@ func ClientID() string {
 		return "$k8s$newforconfig"
 	}
 	nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			"node-role.kubernetes.io/master": "",
-		}).String(),
+		LabelSelector: "node-role.kubernetes.io/master",
 	})
 	if err != nil {
 		return reasonForError(err)


### PR DESCRIPTION
Some installations set the value of node-role.kubernetes.io/master to true instead of just `""` . This will address both cases.