### PR TITLE
Don't block deletion of owner by default.

### DIFF
--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -265,6 +265,8 @@ func EnsureOwnerReference(meta metav1.ObjectMeta, owner *core.ObjectReference) m
 	meta.OwnerReferences[fi].Kind = owner.Kind
 	meta.OwnerReferences[fi].Name = owner.Name
 	meta.OwnerReferences[fi].UID = owner.UID
-	meta.OwnerReferences[fi].BlockOwnerDeletion = types.TrueP()
+	if meta.OwnerReferences[fi].BlockOwnerDeletion == nil {
+		meta.OwnerReferences[fi].BlockOwnerDeletion = types.FalseP()
+	}
 	return meta
 }


### PR DESCRIPTION
To block deletion of synchronous GC of owner, delete permission on owner is required. We generally do want to want to require delete permision on owner. For background, check here: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/synchronous-garbage-collection.md#ownerreference