### PR TITLE
Remove AssignTypeKind and GetGroupVersionKind util methods

### DIFF
--- a/apps/v1/kubernetes.go
+++ b/apps/v1/kubernetes.go
@@ -1,43 +1,7 @@
 package v1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	apps "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return apps.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *apps.StatefulSet:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *apps.Deployment:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *apps.DaemonSet:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *apps.ReplicaSet:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/apps/v1beta1/kubernetes.go
+++ b/apps/v1beta1/kubernetes.go
@@ -1,35 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	apps "k8s.io/api/apps/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return apps.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *apps.StatefulSet:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *apps.Deployment:
-		u.APIVersion = apps.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/batch/v1/kubernetes.go
+++ b/batch/v1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	batch "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return batch.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *batch.Job:
-		u.APIVersion = batch.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/batch/v1beta1/kubernetes.go
+++ b/batch/v1beta1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	batch "k8s.io/api/batch/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return batch.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *batch.CronJob:
-		u.APIVersion = batch.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/certificates/v1beta1/kubernetes.go
+++ b/certificates/v1beta1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	certificates "k8s.io/api/certificates/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return certificates.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *certificates.CertificateSigningRequest:
-		u.APIVersion = certificates.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -2,88 +2,13 @@ package v1
 
 import (
 	"github.com/appscode/go/types"
-	"github.com/appscode/kutil/meta"
 	"github.com/appscode/mergo"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return core.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *core.Pod:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ReplicationController:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ConfigMap:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Secret:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Service:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.PersistentVolumeClaim:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.PersistentVolume:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Node:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ServiceAccount:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Namespace:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Endpoints:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.ComponentStatus:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.LimitRange:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *core.Event:
-		u.APIVersion = core.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}
 
 func RemoveNextInitializer(m metav1.ObjectMeta) metav1.ObjectMeta {
 	if m.GetInitializers() != nil {

--- a/extensions/v1beta1/kubernetes.go
+++ b/extensions/v1beta1/kubernetes.go
@@ -1,47 +1,11 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return extensions.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *extensions.Ingress:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.DaemonSet:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.ReplicaSet:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *extensions.Deployment:
-		u.APIVersion = extensions.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}
 
 func IsOwnedByDeployment(references []metav1.OwnerReference) bool {
 	for _, ref := range references {

--- a/rbac/v1/kubernetes.go
+++ b/rbac/v1/kubernetes.go
@@ -1,43 +1,7 @@
 package v1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	rbac "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return rbac.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *rbac.Role:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.RoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRole:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/rbac/v1beta1/kubernetes.go
+++ b/rbac/v1beta1/kubernetes.go
@@ -1,43 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	rbac "k8s.io/api/rbac/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return rbac.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *rbac.Role:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.RoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRole:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	case *rbac.ClusterRoleBinding:
-		u.APIVersion = rbac.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/storage/v1/kubernetes.go
+++ b/storage/v1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	storage "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return storage.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *storage.StorageClass:
-		u.APIVersion = storage.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}

--- a/storage/v1beta1/kubernetes.go
+++ b/storage/v1beta1/kubernetes.go
@@ -1,31 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/appscode/kutil/meta"
 	"github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	storage "k8s.io/api/storage/v1beta1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var json = jsoniter.ConfigFastest
-
-func GetGroupVersionKind(v interface{}) schema.GroupVersionKind {
-	return storage.SchemeGroupVersion.WithKind(meta.GetKind(v))
-}
-
-func AssignTypeKind(v interface{}) error {
-	_, err := conversion.EnforcePtr(v)
-	if err != nil {
-		return err
-	}
-
-	switch u := v.(type) {
-	case *storage.StorageClass:
-		u.APIVersion = storage.SchemeGroupVersion.String()
-		u.Kind = meta.GetKind(v)
-		return nil
-	}
-	return errors.New("unknown v1beta1 object type")
-}


### PR DESCRIPTION
If this functionality is needed, we should use runtime.Scheme