### PR TITLE
Allow upsert and delete VolumeMounts by MountPath

### DIFF
--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -125,6 +125,25 @@ func EnsureVolumeMountDeleted(mounts []core.VolumeMount, name string) []core.Vol
 	return mounts
 }
 
+func UpsertVolumeMountByPath(mounts []core.VolumeMount, nv core.VolumeMount) []core.VolumeMount {
+	for i, vol := range mounts {
+		if vol.MountPath == nv.MountPath {
+			mounts[i] = nv
+			return mounts
+		}
+	}
+	return append(mounts, nv)
+}
+
+func EnsureVolumeMountDeletedByPath(mounts []core.VolumeMount, mountPath string) []core.VolumeMount {
+	for i, v := range mounts {
+		if v.MountPath == mountPath {
+			return append(mounts[:i], mounts[i+1:]...)
+		}
+	}
+	return mounts
+}
+
 func UpsertEnvVars(vars []core.EnvVar, nv ...core.EnvVar) []core.EnvVar {
 	upsert := func(env core.EnvVar) {
 		for i, v := range vars {


### PR DESCRIPTION
VolumeMounts are unique by their mount path rather than by their name. For example you can mount the same volume named `temp` into `/tmp` and `/run` using sub paths. Currently the Upsert/Delete functions operate by name, so you can mount a volume only once.

I think is useful to have Upsert/Delete functions which operate by path rather than the name of the volume.