### PR TITLE
Support multiple versions and columns for CRDs

### DIFF
--- a/discovery/restmapper_test.go
+++ b/discovery/restmapper_test.go
@@ -11,6 +11,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+
 	// admission "k8s.io/api/admission/v1beta1"
 	// admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	apps "k8s.io/api/apps/v1"
@@ -21,12 +22,14 @@ import (
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	certificates "k8s.io/api/certificates/v1beta1"
 	core "k8s.io/api/core/v1"
+
 	// events "k8s.io/api/events/v1beta1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	// imagepolicy "k8s.io/api/imagepolicy/v1alpha1"
 	networking "k8s.io/api/networking/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
+
 	// scheduling "k8s.io/api/scheduling/v1alpha1"
 	settings "k8s.io/api/settings/v1alpha1"
 	storage "k8s.io/api/storage/v1"

--- a/openapi/render.go
+++ b/openapi/render.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/golang/glog"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+
 	// "k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Multi-version support: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/

Additional Columns: https://github.com/kubernetes/website/pull/9143/files