### PR TITLE
 Fix +/- sign on diff string

### DIFF
--- a/admissionregistration/v1beta1/kubernetes.go
+++ b/admissionregistration/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/admissionregistration/v1beta1/xray.go
+++ b/admissionregistration/v1beta1/xray.go
@@ -8,7 +8,7 @@ import (
 	core_util "github.com/appscode/kutil/core/v1"
 	"github.com/appscode/kutil/discovery"
 	meta_util "github.com/appscode/kutil/meta"
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"

--- a/apps/v1/kubernetes.go
+++ b/apps/v1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/apps/v1beta1/kubernetes.go
+++ b/apps/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/batch/v1/kubernetes.go
+++ b/batch/v1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/batch/v1beta1/kubernetes.go
+++ b/batch/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/certificates/v1beta1/kubernetes.go
+++ b/certificates/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/core/v1/kubernetes.go
+++ b/core/v1/kubernetes.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/appscode/go/types"
 	"github.com/appscode/mergo"
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/discovery/lib.go
+++ b/discovery/lib.go
@@ -3,7 +3,7 @@ package discovery
 import (
 	"fmt"
 
-	"github.com/appscode/go-version"
+	version "github.com/appscode/go-version"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"

--- a/discovery/lib_test.go
+++ b/discovery/lib_test.go
@@ -3,7 +3,7 @@ package discovery
 import (
 	"testing"
 
-	"github.com/appscode/go-version"
+	version "github.com/appscode/go-version"
 )
 
 func TestDefaultSupportedVersion(t *testing.T) {

--- a/dynamic/kubernetes.go
+++ b/dynamic/kubernetes.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/appscode/kutil"
-	"github.com/appscode/kutil/core/v1"
+	v1 "github.com/appscode/kutil/core/v1"
 	discovery_util "github.com/appscode/kutil/discovery"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"

--- a/extensions/v1beta1/kubernetes.go
+++ b/extensions/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/meta/cmp.go
+++ b/meta/cmp.go
@@ -2,7 +2,7 @@ package meta
 
 import (
 	"github.com/google/go-cmp/cmp"
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	jsondiff "github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/meta/hash.go
+++ b/meta/hash.go
@@ -134,7 +134,7 @@ func AlreadyObserved2(old, nu interface{}, enableStatusSubresource bool) bool {
 	}
 
 	if !match && bool(glog.V(log.LevelDebug)) {
-		diff := Diff(nu, old)
+		diff := Diff(old, nu)
 		glog.V(log.LevelDebug).Infof("%s %s/%s has changed. Diff: %s", GetKind(old), oldObj.GetNamespace(), oldObj.GetName(), diff)
 	}
 	return match

--- a/meta/patch.go
+++ b/meta/patch.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	jp "github.com/appscode/jsonpatch"
-	"github.com/evanphx/json-patch"
-	"github.com/json-iterator/go"
+	jsonpatch "github.com/evanphx/json-patch"
+	jsoniter "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )

--- a/rbac/v1/kubernetes.go
+++ b/rbac/v1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/rbac/v1beta1/kubernetes.go
+++ b/rbac/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/storage/v1/kubernetes.go
+++ b/storage/v1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/storage/v1beta1/kubernetes.go
+++ b/storage/v1beta1/kubernetes.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var json = jsoniter.ConfigFastest

--- a/tools/cli/cli.go
+++ b/tools/cli/cli.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/appscode/go/log/golog"
 	"github.com/appscode/kutil/tools/analytics"
-	"github.com/jpillora/go-ogle-analytics"
+	ga "github.com/jpillora/go-ogle-analytics"
 	"github.com/spf13/cobra"
 )
 

--- a/tools/controller/client_builder.go
+++ b/tools/controller/client_builder.go
@@ -23,7 +23,7 @@ import (
 	core_util "github.com/appscode/kutil/core/v1"
 	"github.com/golang/glog"
 	v1authenticationapi "k8s.io/api/authentication/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/tools/controller/controller_ref_manager.go
+++ b/tools/controller/controller_ref_manager.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/tools/controller/controller_ref_manager_test.go
+++ b/tools/controller/controller_ref_manager_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/tools/controller/controller_utils.go
+++ b/tools/controller/controller_utils.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tools/controller/controller_utils_test.go
+++ b/tools/controller/controller_utils_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/tools/docker/lib.go
+++ b/tools/docker/lib.go
@@ -12,7 +12,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/kubernetes/pkg/credentialprovider"

--- a/tools/doctor/version.go
+++ b/tools/doctor/version.go
@@ -1,7 +1,7 @@
 package doctor
 
 import (
-	"github.com/appscode/go-version"
+	version "github.com/appscode/go-version"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
```
// The output string will use the "-" symbol to
// indicate elements removed from x, and the "+" symbol to indicate elements
// added to y.
//
// Do not depend on this output being stable.
func Diff(x, y interface{}, opts ...Option) string {
...
}
```

As the comment indicates, first parameter (`x`) is old object whereas, `y` is new object.
ref: https://github.com/google/go-cmp/blob/875f8df8b7965f1eac1098d36d677f807ac0b49e/cmp/compare.go#L98:6 